### PR TITLE
feat: 26 simplify topic selection

### DIFF
--- a/hmeg/exercise_generator.py
+++ b/hmeg/exercise_generator.py
@@ -24,7 +24,7 @@ class ExerciseGenerator:
         vocab = vocab or Vocabulary.load(DEFAULT_VOCABULARY_FILE)
 
         if topic_name not in GrammarRegistry.topics:
-            raise RuntimeError(f"Requested an unregistered topic: {topic_name}. Please check the topics' folder.")
+            raise RuntimeError(f"Requested an unregistered topic: {topic_name}. Please run `python hmeg_cli.py list` to see the existing topics.")
 
         templates = []
         for exercise_type in GrammarRegistry.topics[topic_name].exercises:

--- a/hmeg/registry.py
+++ b/hmeg/registry.py
@@ -24,6 +24,32 @@ class GrammarRegistry:
         return list(GrammarRegistry.topics)
 
     @staticmethod
+    def find_topics(topic_name: str) -> list[str]:
+        """
+        Find registered topic that fully or partially matches the provided name.
+
+        Args
+        ----
+        topic_name: str,
+            Full or partial name of the topic to find.
+
+        Returns
+        -------
+        list[str]
+            List of found registered topics. If nothing is found then empty list is returned.
+        """
+
+        if not topic_name:
+            return []
+
+        res = []
+        lower_topic_name = topic_name.lower()
+        for cur_topic in GrammarRegistry.topics:
+            if lower_topic_name in cur_topic.lower():
+                res.append(cur_topic)
+        return res
+
+    @staticmethod
     def generate_answers(exercises: list[str], grammar_topic: str | None = None) -> list[list[str]]:
         """
         Generate list of possible answers for the given exercises.

--- a/hmeg/registry.py
+++ b/hmeg/registry.py
@@ -11,6 +11,10 @@ class GrammarRegistry:
     topics: dict[str, GrammarDescription] = dict()
 
     @staticmethod
+    def reset():
+        GrammarRegistry.topics = dict()
+
+    @staticmethod
     def register_grammar_topic(grammar_descr: GrammarDescription):
         if grammar_descr.name in GrammarRegistry.topics:
             return

--- a/hmeg/topics/2_please_do_it_for_me.toml
+++ b/hmeg/topics/2_please_do_it_for_me.toml
@@ -5,6 +5,6 @@ levels=[
 links=[]
 exercises=[
     """
-    S -> '{verb}'
+    S -> 'Please {verb} for me.'
     """
 ]

--- a/hmeg_cli.py
+++ b/hmeg_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fire
+import numpy as np
 import sys
 import toml
 
@@ -34,17 +35,32 @@ class Runner:
         """
         Prints list of registered topics.
         """
-        for topic, descr in GrammarRegistry.topics.items():
-            print(topic)
+        topics = GrammarRegistry.get_registered_topics()
+        print("\n".join(topics))
 
     def run(self):
         """
         Runs generation of exercises and prints them on the screen.
         """
-        exercises = ExerciseGenerator.generate_exercises(
-            topic_name=self.topic, num=self.num_exercises, vocab=self.vocab
-        )
-        print(f"Exercises for topic: {self.topic}")
+
+        topics = GrammarRegistry.find_topics(self.topic)
+        if len(topics) == 0:
+            print(f"Requested an unregistered topic: {self.topic}. Please run `python hmeg_cli.py list` to see the existing topics.")
+            return
+        elif len(topics) == 1:
+            print(f"Exercises for topic: {self.topic}")
+        elif len(topics) > 1:
+            print(f"Exercises for topics:")
+            for topic in topics:
+                print(f"\t{topic}")
+
+        exercises = []
+        for k in range(self.num_exercises):
+            cur_topic = np.random.choice(topics)
+            [cur_exercise] = ExerciseGenerator.generate_exercises(
+                topic_name=cur_topic, num=1, vocab=self.vocab
+            )
+            exercises.append(cur_exercise)
         for idx, exercise in enumerate(exercises):
             print(f"{idx + 1}. {exercise}")
 

--- a/tests/test_exercise_generator.py
+++ b/tests/test_exercise_generator.py
@@ -10,15 +10,15 @@ class TestExerciseGenerator(unittest.TestCase):
         super().setUp(cls)
         utils.register_grammar_topics("hmeg/topics/")
 
-    def test_generate(self):
+    def test_generate_exercises(self):
         for topic in GrammarRegistry.topics:
-            ress = ExerciseGenerator.generate_exercises(topic, num=10)
-            self.assertEqual(len(ress), 10)
+            exercises = ExerciseGenerator.generate_exercises(topic, num=10)
+            self.assertEqual(len(exercises), 10)
 
             # check that no exercises contain placeholders.
             for placeholder in VocabularyPlaceholders.to_list():
-                self.assertTrue(all(placeholder not in res for res in ress))
+                self.assertTrue(all(placeholder not in res for res in exercises))
 
-    def test_generate_unregistered_topic(self):
+    def test_generate_exercises_unregistered_topic(self):
         with self.assertRaises(RuntimeError):
             ExerciseGenerator.generate_exercises("bad topic", num=10)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,36 @@
+import unittest
+
+from hmeg import GrammarRegistry, utils
+
+
+class GrammarRegistryTest(unittest.TestCase):
+    def test_find_topic(self):
+        with self.subTest("Empty registry"):
+            topics = GrammarRegistry.find_topics("I want to… / -고 싶어요")
+            self.assertEqual(topics, [])
+
+        with self.subTest("Empty topic name"):
+            utils.register_grammar_topics()
+            topics = GrammarRegistry.find_topics("")
+            self.assertEqual(topics, [])
+
+            topics = GrammarRegistry.find_topics(None)
+            self.assertEqual(topics, [])
+
+        with self.subTest("Non-existing topic"):
+            topics = GrammarRegistry.find_topics("Non-existing topic")
+            self.assertEqual(topics, [])
+
+        with self.subTest("Exact match"):
+            topics = GrammarRegistry.find_topics("I want to… / -고 싶어요")
+            self.assertEqual(topics, ["I want to… / -고 싶어요"])
+
+        with self.subTest("Multiple matches"):
+            topics = GrammarRegistry.find_topics("면")
+            expected = ['While / -(으)면서', 'If, In case / 만약, -(으)면']
+            self.assertListEqual(topics, expected)
+
+        with self.subTest("Case sensitivity"):
+            topics1 = GrammarRegistry.find_topics("Please")
+            topics2 = GrammarRegistry.find_topics("please")
+            self.assertListEqual(topics1, topics2)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,8 @@ from hmeg import GrammarRegistry, utils
 
 class GrammarRegistryTest(unittest.TestCase):
     def test_find_topic(self):
+        GrammarRegistry.reset()
+
         with self.subTest("Empty registry"):
             topics = GrammarRegistry.find_topics("I want to… / -고 싶어요")
             self.assertEqual(topics, [])


### PR DESCRIPTION
# Changes:
* Add `find_topics` + unit-test
* Add `reset` to `GrammarRegistry`
* Add support for the partial topic name in the CLI

Closes #26 